### PR TITLE
Add Cylc Flow's testing Bash image

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -1,0 +1,41 @@
+name: Create and publish the Cylc bash Docker image for testing
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  # IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: cylc-bash-testing
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./bash
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -33,7 +33,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v2
         with:
           context: ./bash
           push: true

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -6,7 +6,7 @@ on:
 env:
   REGISTRY: ghcr.io
   # IMAGE_NAME: ${{ github.repository }}
-  IMAGE_NAME: cylc-bash-testing
+  IMAGE_NAME: cylc/cylc-bash-testing
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -1,0 +1,53 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Based on:
+#  - https://github.com/themattrix/bashup
+
+RUN apt-get update && apt-get install -y \
+    at \
+    lsof \
+    python3.7 \
+    python3-pip \
+    python3.7-dev \
+    sqlite3 \
+    wget \
+    rsync \
+    && python3.7 -m pip install -U pip setuptools \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /docker-scripts
+COPY build-bash /docker-scripts/
+COPY build-bash-versions /docker-scripts/
+RUN chmod +x /docker-scripts/* \
+    && mv /docker-scripts/* /usr/local/bin/ \
+    && rm -rf /docker-scripts
+
+VOLUME ["/root/cylc-flow"]
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV USER=root
+
+WORKDIR /
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
+
+ENV BASH_VERSIONS_DIR /bash
+RUN mkdir $BASH_VERSIONS_DIR \
+    && build-bash-versions 3.2 4.2 5.0
+
+# the last parameter is the priority, the highest value is picked by default
+RUN update-alternatives --install /bin/bash bash /bash/bash-3.2 1 && \
+    update-alternatives --install /bin/bash bash /bash/bash-4.2 2 && \
+    update-alternatives --install /bin/bash bash /bash/bash-5.0 3 && \
+    update-alternatives --force --all && \
+    update-alternatives --list bash
+
+COPY global.cylc /root/.cylc/flow/global.cylc
+COPY global.cylc /root/.cylc/flow/global-tests.cylc
+
+# To change the system bash version, use for example:
+# `update-alternatives --set bash /bash/bash-4.2`
+# Or if using a terminal, `update-alternatives --config bash` then choose one

--- a/bash/README.md
+++ b/bash/README.md
@@ -1,0 +1,7 @@
+# Cylc Docker bash (testing)
+
+Docker image used by Cylc Flow for testing different versions of bash.
+This is pushed to GitHub Container Registry, and used in Cylc Flow GitHub
+Actions to run functional tests.
+
+Based on <https://github.com/themattrix/bashup>.

--- a/bash/build-bash
+++ b/bash/build-bash
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+readonly VERSION=${1}
+readonly BASH_DIR="bash-${VERSION}"
+readonly BASH_TAR="bash-${VERSION}.tar.gz"
+
+wget -q "http://ftpmirror.gnu.org/bash/bash-${VERSION}.tar.gz"
+tar -xzf "${BASH_TAR}"
+cd "${BASH_DIR}"
+./configure
+make
+mv bash "${BASH_VERSIONS_DIR}/bash-${VERSION}"

--- a/bash/build-bash-versions
+++ b/bash/build-bash-versions
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+mkdir /build
+(cd /build; echo "$@" | xargs -n 1 -P 8 build-bash)
+rm -rf /build

--- a/bash/global.cylc
+++ b/bash/global.cylc
@@ -1,0 +1,3 @@
+[platforms]
+    [[_local_background_indep_tcp]]
+        hosts = localhost


### PR DESCRIPTION
Moves the Docker image from Cylc Flow to this repository, adding a GH Action that can be triggered manually to build and publish it.

This way we should be able to maintain the image in this repository, keeping issues separated from the Cylc Flow issues, publish it, and use it in Cylc Flow and any other repository where we need to test different Bash versions.

Having the image published to the GitHub Container Registry should speed up the build time of Cylc Flow, and avoid brittle tests where for any reason building the Docker image might fail (I believe that has happened in the past days/weeks).

I've merged it into my fork's main branch, and triggered it but with a different image name (kinow/):

- https://github.com/kinow/cylc-docker-1
- https://github.com/kinow/cylc-docker-1/pkgs/container/cylc-bash-testing

Not sure if the `cylc/` prefix in the image name will work, but I guess we will see it once it's merged and fine-tune it later if necessary?

Bruno