### PR TITLE
Python version 3.12

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -28,12 +28,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: ./bash
           push: true

--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -6,7 +6,7 @@ on:
 env:
   REGISTRY: ghcr.io
   # IMAGE_NAME: ${{ github.repository }}
-  IMAGE_NAME: cylc/cylc-bash-testing
+  IMAGE_NAME: cylc/cylc-bash-testing-2
 
 jobs:
   build-and-push-image:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Report Bugs
 
-Report bugs by opening an issue [on 
+Report bugs by opening an issue [on
 Github](https://github.com/cylc/cylc-docker/issues). Give the version
 affected by the bug (you should test the latest release if possible) and a
 recipe to reproduce the problem.
@@ -23,7 +23,7 @@ be able to consider large changes that appear out of the blue. New
 contributors should add their details to the [Code Contributors
 ](#code-contributors) section of this file as part of their first Pull
 Request, and reviewers are responsible for checking this before merging the
-new branch into *master*. 
+new branch into *master*.
 
 ## Code Contributors
 
@@ -33,6 +33,7 @@ below.
 
  - Hilary Oliver
  - Bruno Kinoshita
+ - Ronnie Dutta
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)

--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -8,13 +8,13 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y \
     at \
     lsof \
-    python3.7 \
+    python3.12 \
     python3-pip \
-    python3.7-dev \
+    python3.12-dev \
     sqlite3 \
     wget \
     rsync \
-    && python3.7 -m pip install -U pip setuptools \
+    && python3.12 -m pip install -U pip setuptools \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-scripts
@@ -32,7 +32,7 @@ ENV USER=root
 
 WORKDIR /
 
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
 
 ENV BASH_VERSIONS_DIR /bash
 RUN mkdir $BASH_VERSIONS_DIR \


### PR DESCRIPTION
Needed for https://github.com/cylc/cylc-flow/pull/6809

Only recent bash version 4.4+ are available on conda-forge so I guess we need to update this instead to be able to test with earlier bash versions

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.

