### PR TITLE
Fix `pip install` failing

### DIFF
--- a/.github/workflows/bash.yml
+++ b/.github/workflows/bash.yml
@@ -1,4 +1,5 @@
 name: Create and publish the Cylc bash Docker image for testing
+# https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry
 
 on:
   workflow_dispatch:

--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     sqlite3 \
     wget \
     rsync \
-    && python3.12 -m pip install -U pip setuptools \
+    && python3.12 -m pip install --break-system-packages -U pip setuptools \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-scripts


### PR DESCRIPTION
Follow-up to #5

> I ran the workflow but it failed with
> 
> ```
> #7 24.75 error: externally-managed-environment
> #7 24.75 
> #7 24.75 × This environment is externally managed
> #7 24.75 ╰─> To install Python packages system-wide, try apt install
> #7 24.75     python3-xyz, where xyz is the package you are trying to
> #7 24.75     install.
> #7 24.75     
> #7 24.75     If you wish to install a non-Debian-packaged Python package,
> #7 24.75     create a virtual environment using python3 -m venv path/to/venv.
> #7 24.75     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
> #7 24.75     sure you have python3-full installed.
> #7 24.75     
> #7 24.75     If you wish to install a non-Debian packaged Python application,
> #7 24.75     it may be easiest to use pipx install xyz, which will manage a
> #7 24.75     virtual environment for you. Make sure you have pipx installed.
> #7 24.75     
> #7 24.75     See /usr/share/doc/python3.12/README.venv for more information.
> #7 24.75 
> #7 24.75 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
> #7 24.75 hint: See PEP 668 for the detailed specification.
> ```
> 
> https://github.com/cylc/cylc-docker/actions/runs/16944669281/job/48022502411#step:5:1249

According to GH Copilot:

> The error occurs because the Dockerfile is attempting to install Python packages system-wide using pip, but the Python environment is marked as "externally managed" (per PEP 668). This is a safeguard implemented by Debian-based systems to prevent breaking the system Python installation. The error suggests using alternatives like apt, virtual environments, or pipx for package management.
>
> Relevance of PEP 668:
> PEP 668 defines a mechanism for marking Python environments as "externally managed" by the operating system. This prevents tools like pip from modifying the system Python installation directly. It encourages safer practices, such as using virtual environments or OS package managers, to avoid conflicts or breaking system dependencies.
