### PR TITLE
Attempt to fix `pip install` failing

### DIFF
--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     sqlite3 \
     wget \
     rsync \
-    && python3.12 -m pip install --break-system-packages -U pip setuptools \
+    && python3.12 -m pip install --break-system-packages --force-reinstall -U pip setuptools \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-scripts

--- a/bash/Dockerfile
+++ b/bash/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && apt-get install -y \
     sqlite3 \
     wget \
     rsync \
-    && python3.12 -m pip install --break-system-packages --force-reinstall -U pip setuptools \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /docker-scripts


### PR DESCRIPTION
#6 failed still

> ERROR: Cannot uninstall pip 24.0, RECORD file not found. Hint: The package was installed by debian.

https://github.com/cylc/cylc-docker/actions/runs/17096678202/job/48482657923#step:5:1259

